### PR TITLE
Update Guava artifact version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<java.version>21</java.version>
 		<slf4j.version>2.0.13</slf4j.version>
 		<log4j.version>3.0.0-alpha1</log4j.version>
-		<guava.version>33.1.0-jre-r3</guava.version>
+		<guava.version>33.3.0-jre-r1</guava.version>
 		<jsr305.version>3.0.2-r6</jsr305.version>
 		<owlapi4.version>4.7.1</owlapi4.version>
 		<puli.version>0.4.0</puli.version>


### PR DESCRIPTION
Update Guava artifact to version `33.3.0-jre-r1` after fixing some JPMS issues in this [PR](https://github.com/ikmdev/jpms-deps/pull/68).