### PR TITLE
Java 24 Update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,14 +17,14 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Pull Request Version Validation
-        uses: ikmdev/maven-pull-request-version-validation-action@v2
+        uses: ikmdev/maven-pull-request-version-validation-action@v2.1.0
         
   build-job:
     name: Build Job
     runs-on: ubuntu-24.04
     steps:           
       - name: Build IKMDEV Code
-        uses: ikmdev/maven-clean-install-build-action@v3
+        uses: ikmdev/maven-clean-install-build-action@v3.5.0
         with:
           branch_name: ${{github.ref_name}}
          

--- a/.github/workflows/post_build.yaml
+++ b/.github/workflows/post_build.yaml
@@ -27,7 +27,7 @@ jobs:
           
       - name: IKMDEV Post Build Action
         id: ikmdev_post_build
-        uses: ikmdev/maven-post-build-action@v3.1.0
+        uses: ikmdev/maven-post-build-action@v3.2.0
         with:
             nexus_repo_password: ${{secrets.EC2_NEXUS_PASSWORD}}
             branch_name: ${{github.event.workflow_run.head_branch}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
           token: ${{secrets.IKMDEVOPS_PAT_TOKEN}}
 
       - name: Shared Release Action
-        uses: ikmdev/maven-semver-release-action@v2
+        uses: ikmdev/maven-semver-release-action@v2.7.0
         with:
           version_type: ${{ github.event.inputs.version_type }}
           github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
---enable-preview

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Primary changes:
 * Replace custom collections with Eclipse collections
 * Addition of SNOMED POJO model, reasoner, and parser (without dependency on the OWLAPI)
 
-Requires Java 23.
+Requires Java 24.
 Requires Maven 3.9.11
 Requires Git
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Primary changes:
 * Addition of SNOMED POJO model, reasoner, and parser (without dependency on the OWLAPI)
 
 Requires Java 23.
+Requires Maven 3.9.11
+Requires Git
 
 To build on Unix/Linux/OSX: `./mvnw clean install`
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>dev.ikm.build</groupId>
 		<artifactId>java-parent</artifactId>
-		<version>1.63.0</version>
+		<version>1.64.0</version>
 		<relativePath />
 	</parent>
 
@@ -60,11 +60,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>24</java.version>
 		<java.compilerArgs></java.compilerArgs>
-
-		<!-- Properties Needed To Build On Java 24 (Start) -->
-		<maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
-		<maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>
-		<!-- Properties Needed To Build On Java 24 (End) -->
 
 		<!-- logging dependencies -->
 		<slf4j.version>2.0.17</slf4j.version>
@@ -564,14 +559,14 @@
 						</configuration>
 					</execution>
 				</executions>
-				<dependencies>
-					<!-- Necessary for JDK 24. Should be removed for updates of dependency plugin -->
-					<dependency>
-						<groupId>org.apache.maven.shared</groupId>
-						<artifactId>maven-dependency-analyzer</artifactId>
-						<version>${maven-dependency-analyzer.version}</version>
-					</dependency>
-				</dependencies>
+<!--				<dependencies>-->
+<!--					&lt;!&ndash; Necessary for JDK 24. Should be removed for updates of dependency plugin &ndash;&gt;-->
+<!--					<dependency>-->
+<!--						<groupId>org.apache.maven.shared</groupId>-->
+<!--						<artifactId>maven-dependency-analyzer</artifactId>-->
+<!--						<version>${maven-dependency-analyzer.version}</version>-->
+<!--					</dependency>-->
+<!--				</dependencies>-->
 			</plugin>
 		</plugins>
 	</build>
@@ -629,28 +624,4 @@
 			</plugin>
 		</plugins>
 	</reporting>
-
-	<profiles>
-	<!-- codeQuality profile to override pmd configuration from build-parent
-     Need to ovverride aggregate parameter as it is deprecated. -->
-	<profile>
-		<!-- To disable this, use something like "mvn install -P!codeQuality" -->
-		<id>codeQuality</id>
-		<activation>
-			<activeByDefault>false</activeByDefault>
-		</activation>
-		<build>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-pmd-plugin</artifactId>
-					<configuration>
-						<aggregate combine.self="override"></aggregate> <!-- Overridden due to deprecation -->
-						<targetJdk>${java.version}</targetJdk>
-					</configuration>
-				</plugin>
-			</plugins>
-		</build>
-	</profile>
-</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>dev.ikm.build</groupId>
 		<artifactId>java-parent</artifactId>
 		<version>1.64.0</version>
-		<relativePath />
 	</parent>
 
 	<groupId>dev.ikm.elk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>23</java.version>
+		<java.version>24</java.version>
 		<java.compilerArgs></java.compilerArgs>
 		<!-- logging dependencies -->
 		<slf4j.version>2.0.17</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>24</java.version>
 		<java.compilerArgs></java.compilerArgs>
+
+		<!-- Properties Needed To Build On Java 24 (Start) -->
+		<maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
+		<maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>
+		<!-- Properties Needed To Build On Java 24 (End) -->
+
 		<!-- logging dependencies -->
 		<slf4j.version>2.0.17</slf4j.version>
 		<log4j.version>3.0.0-alpha1</log4j.version>
@@ -552,6 +558,14 @@
 						</configuration>
 					</execution>
 				</executions>
+				<dependencies>
+					<!-- Necessary for JDK 24. Should be removed for updates of dependency plugin -->
+					<dependency>
+						<groupId>org.apache.maven.shared</groupId>
+						<artifactId>maven-dependency-analyzer</artifactId>
+						<version>${maven-dependency-analyzer.version}</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
@@ -609,4 +623,28 @@
 			</plugin>
 		</plugins>
 	</reporting>
+
+	<profiles>
+	<!-- codeQuality profile to override pmd configuration from build-parent
+     Need to ovverride aggregate parameter as it is deprecated. -->
+	<profile>
+		<!-- To disable this, use something like "mvn install -P!codeQuality" -->
+		<id>codeQuality</id>
+		<activation>
+			<activeByDefault>false</activeByDefault>
+		</activation>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-pmd-plugin</artifactId>
+					<configuration>
+						<aggregate combine.self="override"></aggregate> <!-- Overridden due to deprecation -->
+						<targetJdk>${java.version}</targetJdk>
+					</configuration>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
+</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -559,14 +559,6 @@
 						</configuration>
 					</execution>
 				</executions>
-<!--				<dependencies>-->
-<!--					&lt;!&ndash; Necessary for JDK 24. Should be removed for updates of dependency plugin &ndash;&gt;-->
-<!--					<dependency>-->
-<!--						<groupId>org.apache.maven.shared</groupId>-->
-<!--						<artifactId>maven-dependency-analyzer</artifactId>-->
-<!--						<version>${maven-dependency-analyzer.version}</version>-->
-<!--					</dependency>-->
-<!--				</dependencies>-->
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
- Updated the GH Actions to us newer released versions
    - build.yaml
        - ikmdev/maven-pull-request-version-validation-action@v2.1.0
        - ikmdev/maven-clean-install-build-action@v3.5.0
        - ikmdev/maven-post-build-action@v3.2.0
        - ikmdev/maven-semver-release-action@v2.7.0

- Updated the maven wrapper to 3.9.11

- Added some properties
        - <java.version>24</java.version>
        - <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
        - <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>

- Added codeQuality profile to override maven-pmd-plugin (aggregate parameter is deprecated)

- Added transitive dependency fix for maven-dependency-plugin

- Removed "--enable-preview" from codebase